### PR TITLE
Fix Windows path handling

### DIFF
--- a/lib/file-updater.js
+++ b/lib/file-updater.js
@@ -3,6 +3,7 @@ import ora from 'ora'
 import got from 'got'
 import config from './config.js'
 import chalk from 'chalk'
+import path from 'path';
 
 export async function updateFile(files, reset = false) {
 
@@ -44,18 +45,18 @@ export async function updateAllFiles() {
     folds.forEach(folder => {
         const files = fs.readdirSync(folder);   
         files.forEach(file => {
-            const path = `${folder}/${file}`;
+            const filePath = path.join(folder, file);
 
             if (
-                fs.lstatSync(path).isDirectory() ||
+                fs.lstatSync(filePath).isDirectory() ||
                 file.match(/^\./)
             ) 
                 return;
 
-            // ./config.yaml to /config.yaml
-            const cleanPath = path.replace(/^\./, '')
+            // Get the relative path, normalize it, and remove leading './' 
+            const cleanPath = path.relative('.', filePath).replace(/\\/g, '/').replace(/^\.\//, '');
 
-            paths[cleanPath] = fs.readFileSync(path);
+            paths[cleanPath] = fs.readFileSync(filePath);
         });
     })
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -3,6 +3,12 @@ import fs from 'fs'
 import { updateFile } from './file-updater.js'
 import path from 'path';
 
+
+function normalizePath(filePath) {
+    // Normalize the path and replace backslashes with forward slashes
+    return path.normalize(filePath).replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
 /**
  * Watches file changes and syncs with production
  */
@@ -15,17 +21,17 @@ export default async function watch() {
         // only one folder level
         depth: 1,
         ignoreInitial: true
-    }).on('all', function(event, path) {
+    }).on('all', function(event, filePath) {
 
         let content;
         try {
-            content = fs.readFileSync(path, 'utf8');
+            content = fs.readFileSync(filePath, 'utf8');
         } catch {
             // returns error on reading dir
             return;
         }
-
-        updateFile({[path]: content})
+        const normalizedPath = normalizePath(filePath);
+        updateFile({[normalizedPath]: content})
 
     });
 


### PR DESCRIPTION
This PR addresses an issue where the CLI was not handling Windows file paths correctly, resulting in improper file syncing and creation of misplaced files. I also made sure that the original path cleaning behavior is maintained.

If you use this PR, please test on Linux and MacOS as I did not test the changes on those systems.

Key changes:

**1. In watch.js:**
- Added normalizePath function for consistent path handling
- Applied it before updateFile calls

**2. In file-updater.js:**
- Added import for the path module.
- Used path.join() and path.relative() for better path handling
- Kept the './' removal from paths

**Testing:**
- Tested on Windows 11.
- Verified correct handling of individual file updates and initial bulk sync.
- Confirmed that files in subdirectories are correctly updated without creating misplaced files in the root directory.